### PR TITLE
Add SDL 1.2 dev libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,8 @@ RUN dpkg --add-architecture i386 && \
         libswitch-perl \
         libasound2-dev \
         libc6:i386 \
-        libstdc++6:i386
+        libstdc++6:i386 \
+        libsdl1.2-dev
 
 RUN git config --global user.email "you@example.com" && \
         git config --global user.name "Your Name"


### PR DESCRIPTION
These are not strictly required but a nice to have when building AROS.

Would it make sense to add this to the general base image?